### PR TITLE
chore(build): add Visual Studio 2019 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Unicode formats other than UTF-8 aren't supported.
 
 ## Supported platforms
 
-*  Windows VS2015 x86 and x64, VS2017 x86, x64, and ARM64*
+*  Windows VS2015 x86 and x64, VS2017/2019 x86, x64, and ARM64*
 *  Linux (gcc5, gcc6, gcc7, gcc8, clang4, clang5, clang6) x86 and x64
 *  OS X (Xcode 8.3, Xcode 9.4, Xcode 10.1) x86 and x64
 *  Android (NVIDIA CodeWorks) ARMv7-A and ARM64
@@ -43,7 +43,7 @@ Unicode formats other than UTF-8 aren't supported.
 
 The above supported platform list is only what is tested every release but if it compiles, it should run just fine.
 
-Note: *VS2017* compiles with *ARM64* on *AppVeyor* but I have no device to test it with.
+Note: *VS2017* and *VS2019* compile with *ARM64* on *AppVeyor* but I have no device to test them with.
 
 ## External dependencies
 
@@ -56,7 +56,7 @@ This library is **100%** headers as such you just need to include them in your o
 
 ### Windows, Linux, and OS X for x86 and x64
 
-1. Install *CMake 3.2* or higher (*3.10* is required on OS X with *Xcode 10*), *Python 3*, and the proper compiler for your platform.
+1. Install *CMake 3.2* or higher (*3.14* for Visual Studio 2019, or *3.10* on OS X with *Xcode 10*), *Python 3*, and the proper compiler for your platform.
 2. Execute `git submodule update --init` to get the files of thirdparty submodules (e.g. Catch2).
 3. Generate the IDE solution with: `python make.py`  
    The solution is generated under `./build`  

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,10 +2,12 @@ version: 0.6.0.{build}
 
 environment:
   PYTHON: "C:\\Python33-x64"
+  VISUAL_STUDIO: "C:\\Program Files (x86)\\Microsoft Visual Studio"
 
 image:
 - Visual Studio 2015
 - Visual Studio 2017
+- Visual Studio 2019
 
 install:
 - cmd: >-
@@ -15,7 +17,11 @@ build_script:
 - cmd: >-
     IF "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2015" (SET COMPILER=vs2015)
 
-    IF "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2017" (SET COMPILER=vs2017)
+    IF "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2017" (SET COMPILER=vs2017 && SET ARM64_SUPPORTED=1)
+
+    IF "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2019" (SET COMPILER=vs2019 && SET ARM64_SUPPORTED=1)
+
+    IF "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2019" "%VISUAL_STUDIO%\\Installer\\vs_installershell.exe" modify --productId Microsoft.VisualStudio.Product.Community --channelId VisualStudio.16.Release --add Microsoft.VisualStudio.Component.VC.Tools.ARM64 --add Microsoft.VisualStudio.Component.VC.Runtimes.ARM64.Spectre --quiet
 
     %PYTHON%\\python.exe make.py -clean -build -unit_test -compiler %COMPILER% -config Debug -cpu x86
 
@@ -25,6 +31,6 @@ build_script:
 
     %PYTHON%\\python.exe make.py -clean -build -unit_test -compiler %COMPILER% -config Release -cpu x64
 
-    IF "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2017" %PYTHON%\\python.exe make.py -clean -build -compiler %COMPILER% -config Debug -cpu arm64
+    IF DEFINED ARM64_SUPPORTED %PYTHON%\\python.exe make.py -clean -build -compiler %COMPILER% -config Debug -cpu arm64
 
-    IF "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2017" %PYTHON%\\python.exe make.py -clean -build -compiler %COMPILER% -config Release -cpu arm64
+    IF DEFINED ARM64_SUPPORTED %PYTHON%\\python.exe make.py -clean -build -compiler %COMPILER% -config Release -cpu arm64

--- a/make.py
+++ b/make.py
@@ -18,7 +18,7 @@ def parse_argv():
 	actions.add_argument('-unit_test', action='store_true')
 
 	target = parser.add_argument_group(title='Target')
-	target.add_argument('-compiler', choices=['vs2015', 'vs2017', 'android', 'clang4', 'clang5', 'clang6', 'gcc5', 'gcc6', 'gcc7', 'gcc8', 'osx', 'ios'], help='Defaults to the host system\'s default compiler')
+	target.add_argument('-compiler', choices=['vs2015', 'vs2017', 'vs2019', 'android', 'clang4', 'clang5', 'clang6', 'gcc5', 'gcc6', 'gcc7', 'gcc8', 'osx', 'ios'], help='Defaults to the host system\'s default compiler')
 	target.add_argument('-config', choices=['Debug', 'Release'], type=str.capitalize)
 	target.add_argument('-cpu', choices=['x86', 'x64', 'arm64'], help='Only supported for Windows, OS X, and Linux; defaults to the host system\'s architecture')
 
@@ -47,8 +47,8 @@ def parse_argv():
 			sys.exit(1)
 
 	if args.cpu == 'arm64':
-		if not args.compiler in ['vs2017', 'ios']:
-			print('ARM64 is only supported with VS2017 and iOS')
+		if not args.compiler in ['vs2017', 'vs2019', 'ios']:
+			print('ARM64 is only supported with VS2017, VS2019, and iOS')
 			sys.exit(1)
 
 	return args
@@ -78,6 +78,8 @@ def get_generator(compiler, cpu):
 				# VS2017 ARM/ARM64 support only works with cmake 3.13 and up and the architecture must be specified with
 				# the -A cmake switch
 				return 'Visual Studio 15 2017'
+		elif compiler == 'vs2019':
+			return 'Visual Studio 16 2019'
 		elif compiler == 'android':
 			return 'Visual Studio 14'
 	elif platform.system() == 'Darwin':
@@ -98,6 +100,11 @@ def get_architecture(compiler, cpu):
 		if compiler == 'vs2017':
 			if cpu == 'arm64':
 				return 'ARM64'
+		elif compiler == 'vs2019':
+			if cpu == 'x86':
+				return 'Win32'
+			else:
+				return cpu
 
 	# This compiler/cpu pair does not need the architecture switch
 	return None

--- a/tools/release_scripts/test_everything.py
+++ b/tools/release_scripts/test_everything.py
@@ -5,7 +5,7 @@ import sys
 
 def get_platform_compilers():
 	if platform.system() == 'Windows':
-		return [ 'vs2015', 'vs2017' ]
+		return [ 'vs2015', 'vs2017', 'vs2019' ]
 	elif platform.system() == 'Linux':
 		return [ 'gcc5', 'gcc6', 'gcc7', 'clang4', 'clang5' ]
 	elif platform.system() == 'Darwin':


### PR DESCRIPTION
The SFINAE hack that VS2017 required does not work in VS2019, although I did not look into this;
the std::function overloads used for VS2015 work fine.

CMake 3.14 or newer is required to build with VS2019.